### PR TITLE
Added check for empty vector

### DIFF
--- a/helper.cpp
+++ b/helper.cpp
@@ -212,11 +212,19 @@ char* exiv2_xmp_datum_to_string(const Exiv2XmpDatum *datum)
 
     if (typeId == Exiv2::xmpBag) {
         strval = datum->datum.toString();
+    } else if (typeId == Exiv2::xmpSeq) {
+        strval = datum->datum.size()==0 ? "" : datum->datum.toString(0);	
     } else {
         strval = datum->datum.toString(0);
     }
 
 	return strdup(strval.c_str());
+}
+
+char *exiv2_xmp_datum_type(const Exiv2XmpDatum *datum)
+{
+	const std::string strtypename = datum->datum.typeName();
+	return strdup(strtypename.c_str());
 }
 
 void exiv2_xmp_datum_free(Exiv2XmpDatum *x) { delete x; };

--- a/helper.h
+++ b/helper.h
@@ -36,6 +36,7 @@ Exiv2XmpData* exiv2_image_get_xmp_data(const Exiv2Image *img);
 void exiv2_xmp_data_free(Exiv2XmpData *data);
  const char *exiv2_xmp_datum_key(const Exiv2XmpDatum *datum);
 char* exiv2_xmp_datum_to_string(const Exiv2XmpDatum *datum);
+char* exiv2_xmp_datum_type(const Exiv2XmpDatum *datum);
 void exiv2_xmp_datum_free(Exiv2XmpDatum *datum);
 Exiv2XmpDatum* exiv2_xmp_data_find_key(const Exiv2XmpData *data, const char *key, Exiv2Error **error);
 Exiv2XmpDatumIterator *exiv2_xmp_data_iterator(const Exiv2XmpData *data);

--- a/xmp.go
+++ b/xmp.go
@@ -96,6 +96,13 @@ func (d *XmpDatum) String() string {
 	return C.GoString(cstr)
 }
 
+func (d *XmpDatum) Type() string {
+	cstr := C.exiv2_xmp_datum_type(d.datum)
+	defer C.free(unsafe.Pointer(cstr))
+
+	return C.GoString(cstr)
+}
+
 // Iterator returns a new ExifDatumIterator to iterate over all Exif data.
 func (d *XmpData) Iterator() *XmpDatumIterator {
 	return makeXmpDatumIterator(d, C.exiv2_xmp_data_iterator(d.data))


### PR DESCRIPTION
Had an instance of the string call causing a `what(): vector::_M_range_check: __n (which is 0) >=...` This adds a check to see if the vector is empty before returning the first item